### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/872/080/3/1108720803.geojson
+++ b/data/110/872/080/3/1108720803.geojson
@@ -241,6 +241,9 @@
     "wof:concordances":{},
     "wof:country":"IL",
     "wof:created":1476124687,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"246296e8c46435df693c9e252bae1d42",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":1108720803,
-    "wof:lastmodified":1566680605,
+    "wof:lastmodified":1582356363,
     "wof:name":"Sea of Galilee",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/080/5/1108720805.geojson
+++ b/data/110/872/080/5/1108720805.geojson
@@ -87,6 +87,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124689,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"4d87466f63edec95d8a6417030a8adaa",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":1108720805,
-    "wof:lastmodified":1566680605,
+    "wof:lastmodified":1582356363,
     "wof:name":"Sharon",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/080/7/1108720807.geojson
+++ b/data/110/872/080/7/1108720807.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124690,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"7f43f723bd22dfb445c7f907ce7f6868",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720807,
-    "wof:lastmodified":1566680604,
+    "wof:lastmodified":1582356363,
     "wof:name":"Akko",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/081/1/1108720811.geojson
+++ b/data/110/872/081/1/1108720811.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124692,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"733d0014a683df98053e3c7181f11ba7",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":1108720811,
-    "wof:lastmodified":1566680608,
+    "wof:lastmodified":1582356364,
     "wof:name":"Golan",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/872/081/3/1108720813.geojson
+++ b/data/110/872/081/3/1108720813.geojson
@@ -189,6 +189,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124695,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"16515bfa76e6514160b88e1cff615f56",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":1108720813,
-    "wof:lastmodified":1566680612,
+    "wof:lastmodified":1582356367,
     "wof:name":"Rehovot",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/081/5/1108720815.geojson
+++ b/data/110/872/081/5/1108720815.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124696,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"6d3294df5be80e2e7246ae6a953f35e6",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":1108720815,
-    "wof:lastmodified":1566680612,
+    "wof:lastmodified":1582356367,
     "wof:name":"Ramla",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/081/7/1108720817.geojson
+++ b/data/110/872/081/7/1108720817.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124697,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"1fcab4b0e0d233bc8d81494ae6a8b389",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720817,
-    "wof:lastmodified":1566680606,
+    "wof:lastmodified":1582356363,
     "wof:name":"Be'er Sheva",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/081/9/1108720819.geojson
+++ b/data/110/872/081/9/1108720819.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124698,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"41cfb230894604f03547d411a986f7a3",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":1108720819,
-    "wof:lastmodified":1566680605,
+    "wof:lastmodified":1582356363,
     "wof:name":"Hadera",
     "wof:parent_id":85672535,
     "wof:placetype":"county",

--- a/data/110/872/082/1/1108720821.geojson
+++ b/data/110/872/082/1/1108720821.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124699,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"033a7c42564acfe5516c5c8a65fd8876",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720821,
-    "wof:lastmodified":1566680603,
+    "wof:lastmodified":1582356362,
     "wof:name":"Petah Tiqwa",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/082/3/1108720823.geojson
+++ b/data/110/872/082/3/1108720823.geojson
@@ -235,6 +235,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124701,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"20befe1dc88e8cdcbe1e32e1064b9326",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":1108720823,
-    "wof:lastmodified":1566680604,
+    "wof:lastmodified":1582356362,
     "wof:name":"Jerusalem",
     "wof:parent_id":85672551,
     "wof:placetype":"county",

--- a/data/110/872/082/5/1108720825.geojson
+++ b/data/110/872/082/5/1108720825.geojson
@@ -90,6 +90,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124702,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"4cdb7bd4adccd6abaacc99b98ca10c8b",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":1108720825,
-    "wof:lastmodified":1566680604,
+    "wof:lastmodified":1582356362,
     "wof:name":"Kinneret",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/082/9/1108720829.geojson
+++ b/data/110/872/082/9/1108720829.geojson
@@ -81,6 +81,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124703,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"7c005234bb4154d1d6d51a0fe863154e",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":1108720829,
-    "wof:lastmodified":1566680603,
+    "wof:lastmodified":1582356362,
     "wof:name":"Yizre'el",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/083/1/1108720831.geojson
+++ b/data/110/872/083/1/1108720831.geojson
@@ -394,6 +394,9 @@
     "wof:concordances":{},
     "wof:country":"IL",
     "wof:created":1476124704,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"84adcf7952e357d5b6d7e8ab9c76bbf2",
     "wof:hierarchy":[
         {
@@ -404,7 +407,7 @@
         }
     ],
     "wof:id":1108720831,
-    "wof:lastmodified":1566680601,
+    "wof:lastmodified":1582356361,
     "wof:name":"Dead Sea",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/083/3/1108720833.geojson
+++ b/data/110/872/083/3/1108720833.geojson
@@ -394,6 +394,9 @@
     "wof:concordances":{},
     "wof:country":"IL",
     "wof:created":1476124705,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"e4b9b2af2ee7ac10c43d43ff56c94d59",
     "wof:hierarchy":[
         {
@@ -404,7 +407,7 @@
         }
     ],
     "wof:id":1108720833,
-    "wof:lastmodified":1566680601,
+    "wof:lastmodified":1582356361,
     "wof:name":"Dead Sea",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/083/5/1108720835.geojson
+++ b/data/110/872/083/5/1108720835.geojson
@@ -265,6 +265,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124706,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"e78881ce60e18d110d3c65e0ddec4f1c",
     "wof:hierarchy":[
         {
@@ -275,7 +278,7 @@
         }
     ],
     "wof:id":1108720835,
-    "wof:lastmodified":1566680601,
+    "wof:lastmodified":1582356361,
     "wof:name":"Haifa",
     "wof:parent_id":85672535,
     "wof:placetype":"county",

--- a/data/110/872/083/7/1108720837.geojson
+++ b/data/110/872/083/7/1108720837.geojson
@@ -229,6 +229,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124707,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"a74952296c858756f61f7f161ad06f06",
     "wof:hierarchy":[
         {
@@ -239,7 +242,7 @@
         }
     ],
     "wof:id":1108720837,
-    "wof:lastmodified":1566680601,
+    "wof:lastmodified":1582356360,
     "wof:name":"Tel Aviv",
     "wof:parent_id":85672549,
     "wof:placetype":"county",

--- a/data/110/872/083/9/1108720839.geojson
+++ b/data/110/872/083/9/1108720839.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124709,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"db9e305925bb1db37444e972dc815627",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720839,
-    "wof:lastmodified":1566680598,
+    "wof:lastmodified":1582356358,
     "wof:name":"Zefat",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/084/1/1108720841.geojson
+++ b/data/110/872/084/1/1108720841.geojson
@@ -69,6 +69,9 @@
     },
     "wof:country":"IL",
     "wof:created":1476124711,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"b407642154f6f1294f82b9a4ba0f0148",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":1108720841,
-    "wof:lastmodified":1566680602,
+    "wof:lastmodified":1582356361,
     "wof:name":"Ashqelon",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/112/595/523/9/1125955239.geojson
+++ b/data/112/595/523/9/1125955239.geojson
@@ -568,6 +568,9 @@
     },
     "wof:country":"IL",
     "wof:created":1497297598,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"16120eac26a420a5ffdbf54921c28cce",
     "wof:hierarchy":[
         {
@@ -579,7 +582,7 @@
         }
     ],
     "wof:id":1125955239,
-    "wof:lastmodified":1566680686,
+    "wof:lastmodified":1582356369,
     "wof:name":"Tel Aviv",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/168/681/421168681.geojson
+++ b/data/421/168/681/421168681.geojson
@@ -936,6 +936,9 @@
     ],
     "wof:country":"IL",
     "wof:created":1459008774,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f4ce47426d56003cbf754d712d46b78",
     "wof:hierarchy":[
         {
@@ -947,7 +950,7 @@
         }
     ],
     "wof:id":421168681,
-    "wof:lastmodified":1566680625,
+    "wof:lastmodified":1582356367,
     "wof:name":"Jerusalem",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/421/168/693/421168693.geojson
+++ b/data/421/168/693/421168693.geojson
@@ -489,6 +489,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459008775,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f08854ce105188e53d9e26e5b58ff76",
     "wof:hierarchy":[
         {
@@ -500,7 +503,7 @@
         }
     ],
     "wof:id":421168693,
-    "wof:lastmodified":1566680625,
+    "wof:lastmodified":1582356368,
     "wof:name":"Haifa",
     "wof:parent_id":1108720835,
     "wof:placetype":"locality",

--- a/data/421/174/205/421174205.geojson
+++ b/data/421/174/205/421174205.geojson
@@ -232,6 +232,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009023,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"afb7e0f15d298eefd18e22a8467ad579",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         }
     ],
     "wof:id":421174205,
-    "wof:lastmodified":1566680643,
+    "wof:lastmodified":1582356368,
     "wof:name":"Herzliya",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/175/859/421175859.geojson
+++ b/data/421/175/859/421175859.geojson
@@ -307,6 +307,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009082,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b6118f4be34f447675bd7875c748510",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
         }
     ],
     "wof:id":421175859,
-    "wof:lastmodified":1566680656,
+    "wof:lastmodified":1582356368,
     "wof:name":"Ashdod",
     "wof:parent_id":1108720841,
     "wof:placetype":"locality",

--- a/data/421/177/425/421177425.geojson
+++ b/data/421/177/425/421177425.geojson
@@ -188,6 +188,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81faf39ac90209b3765b55263ee354ae",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":421177425,
-    "wof:lastmodified":1566680674,
+    "wof:lastmodified":1582356369,
     "wof:name":"Giv'atayim",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/179/743/421179743.geojson
+++ b/data/421/179/743/421179743.geojson
@@ -234,6 +234,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009231,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7d99c853084b95de3c0c10c3536a15c",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":421179743,
-    "wof:lastmodified":1566680677,
+    "wof:lastmodified":1582356369,
     "wof:name":"Holon",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/180/791/421180791.geojson
+++ b/data/421/180/791/421180791.geojson
@@ -171,6 +171,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009271,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52141102f7ad088a41622fd5f25a7547",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
         }
     ],
     "wof:id":421180791,
-    "wof:lastmodified":1566680645,
+    "wof:lastmodified":1582356368,
     "wof:name":"Ramat HaSharon",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/182/059/421182059.geojson
+++ b/data/421/182/059/421182059.geojson
@@ -269,6 +269,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009317,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9a63df3e3258d73db9a5458d56164d3",
     "wof:hierarchy":[
         {
@@ -280,7 +283,7 @@
         }
     ],
     "wof:id":421182059,
-    "wof:lastmodified":1566680679,
+    "wof:lastmodified":1582356369,
     "wof:name":"Netanya",
     "wof:parent_id":1108720805,
     "wof:placetype":"locality",

--- a/data/421/183/425/421183425.geojson
+++ b/data/421/183/425/421183425.geojson
@@ -240,6 +240,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009369,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8be1a980382589fadd0540f34f0e2b7e",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
         }
     ],
     "wof:id":421183425,
-    "wof:lastmodified":1566680676,
+    "wof:lastmodified":1582356369,
     "wof:name":"Ramat Gan",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/190/661/421190661.geojson
+++ b/data/421/190/661/421190661.geojson
@@ -227,6 +227,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009665,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c180c4c8a2d498d8df8469037489749b",
     "wof:hierarchy":[
         {
@@ -238,7 +241,7 @@
         }
     ],
     "wof:id":421190661,
-    "wof:lastmodified":1566680662,
+    "wof:lastmodified":1582356368,
     "wof:name":"Bnei Brak",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/193/759/421193759.geojson
+++ b/data/421/193/759/421193759.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009782,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5ab84d8daa982e5e8d62f6aa8ffc522",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421193759,
-    "wof:lastmodified":1566680634,
+    "wof:lastmodified":1582356368,
     "wof:name":"Ramat Modi'in",
     "wof:parent_id":1108720815,
     "wof:placetype":"locality",

--- a/data/421/196/439/421196439.geojson
+++ b/data/421/196/439/421196439.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009881,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d7a4f8f212a5eb398df71d9408660a3",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421196439,
-    "wof:lastmodified":1566680659,
+    "wof:lastmodified":1582356368,
     "wof:name":"Or Yehuda",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/197/319/421197319.geojson
+++ b/data/421/197/319/421197319.geojson
@@ -291,6 +291,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009909,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44f2ee5c451947f4b53c34dca457ded0",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         }
     ],
     "wof:id":421197319,
-    "wof:lastmodified":1566680664,
+    "wof:lastmodified":1582356368,
     "wof:name":"Rishon LeZion",
     "wof:parent_id":1108720813,
     "wof:placetype":"locality",

--- a/data/421/199/251/421199251.geojson
+++ b/data/421/199/251/421199251.geojson
@@ -198,6 +198,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459009983,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6beb3351acfdd8001d58fcd3acb94120",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
         }
     ],
     "wof:id":421199251,
-    "wof:lastmodified":1566680665,
+    "wof:lastmodified":1582356369,
     "wof:name":"Bat Yam",
     "wof:parent_id":1108720837,
     "wof:placetype":"locality",

--- a/data/421/200/701/421200701.geojson
+++ b/data/421/200/701/421200701.geojson
@@ -215,7 +215,6 @@
     "qs:woe_id":24549736,
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -249,6 +248,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459010035,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40fec83af0698238c72707ea7bf72b21",
     "wof:hierarchy":[
         {
@@ -269,7 +271,7 @@
         }
     ],
     "wof:id":421200701,
-    "wof:lastmodified":1566680667,
+    "wof:lastmodified":1582356369,
     "wof:name":"Jerusalem",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/421/202/049/421202049.geojson
+++ b/data/421/202/049/421202049.geojson
@@ -296,6 +296,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459010102,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fc8b748a0019fb3283c09b0906872b65",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         }
     ],
     "wof:id":421202049,
-    "wof:lastmodified":1566680641,
+    "wof:lastmodified":1582356368,
     "wof:name":"Petah Tikva",
     "wof:parent_id":1108720821,
     "wof:placetype":"locality",

--- a/data/421/202/181/421202181.geojson
+++ b/data/421/202/181/421202181.geojson
@@ -428,6 +428,9 @@
     },
     "wof:country":"IL",
     "wof:created":1459010108,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58e3dc5e02f4c4a0da5e680f21288cf6",
     "wof:hierarchy":[
         {
@@ -439,7 +442,7 @@
         }
     ],
     "wof:id":421202181,
-    "wof:lastmodified":1566680641,
+    "wof:lastmodified":1582356368,
     "wof:name":"Beersheba",
     "wof:parent_id":1108720817,
     "wof:placetype":"locality",

--- a/data/856/323/15/85632315.geojson
+++ b/data/856/323/15/85632315.geojson
@@ -1134,6 +1134,12 @@
     },
     "wof:country":"IL",
     "wof:country_alpha3":"ISR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"8c7dcac683ccfa5fd0457479069a5d01",
     "wof:hierarchy":[
         {
@@ -1151,7 +1157,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1566680570,
+    "wof:lastmodified":1582356355,
     "wof:name":"Israel",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/725/31/85672531.geojson
+++ b/data/856/725/31/85672531.geojson
@@ -319,6 +319,10 @@
         "wk:page":"Southern District (Israel)"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"2fc85858853e5d119e0f78c2d1a095ff",
     "wof:hierarchy":[
         {
@@ -336,7 +340,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680569,
+    "wof:lastmodified":1582356354,
     "wof:name":"Southern",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/35/85672535.geojson
+++ b/data/856/725/35/85672535.geojson
@@ -356,6 +356,10 @@
         "wk:page":"Haifa District"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"eafa4ca928d59c6b2a2cee9e1d500dcf",
     "wof:hierarchy":[
         {
@@ -373,7 +377,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680567,
+    "wof:lastmodified":1582356354,
     "wof:name":"Haifa",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/41/85672541.geojson
+++ b/data/856/725/41/85672541.geojson
@@ -299,6 +299,10 @@
         "wk:page":"Central District (Israel)"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"6b56e39faf13e9d52d4d5e3f42586d19",
     "wof:hierarchy":[
         {
@@ -316,7 +320,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680569,
+    "wof:lastmodified":1582356355,
     "wof:name":"Central",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/45/85672545.geojson
+++ b/data/856/725/45/85672545.geojson
@@ -350,6 +350,10 @@
         "wk:page":"Northern District (Israel)"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"7aae0f4a1d371b2aae10af9939145b78",
     "wof:hierarchy":[
         {
@@ -367,7 +371,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680568,
+    "wof:lastmodified":1582356354,
     "wof:name":"Northern",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/49/85672549.geojson
+++ b/data/856/725/49/85672549.geojson
@@ -314,6 +314,10 @@
         "wk:page":"Tel Aviv District"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"a74952296c858756f61f7f161ad06f06",
     "wof:hierarchy":[
         {
@@ -331,7 +335,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680570,
+    "wof:lastmodified":1582356355,
     "wof:name":"Tel Aviv",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/51/85672551.geojson
+++ b/data/856/725/51/85672551.geojson
@@ -342,6 +342,10 @@
         "wk:page":"Jerusalem District"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"a0113587e324b32eedaca294579a4bf6",
     "wof:hierarchy":[
         {
@@ -359,7 +363,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1566680568,
+    "wof:lastmodified":1582356354,
     "wof:name":"Jerusalem",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/859/030/81/85903081.geojson
+++ b/data/859/030/81/85903081.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":221581
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab4ac2895f321a1a184aab7cf000dbf2",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Ah\u0331uzzat Shemu\u2019el",
     "wof:parent_id":421168693,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/87/85903087.geojson
+++ b/data/859/030/87/85903087.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1301546
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cc0ced81d3a571c0e9fb6e8f5045ed1",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Barnea",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/89/85903089.geojson
+++ b/data/859/030/89/85903089.geojson
@@ -78,6 +78,9 @@
         "qs:id":222708
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"405185f1ad59a0faff54020b19a8f82a",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379344,
+    "wof:lastmodified":1582356353,
     "wof:name":"Bat Gallim",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/91/85903091.geojson
+++ b/data/859/030/91/85903091.geojson
@@ -96,6 +96,9 @@
         "wk:page":"Beit HaKerem, Jerusalem"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dbf0ed1bb3d77b901e41ad244266bc7c",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Bet HaKerem",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/97/85903097.geojson
+++ b/data/859/030/97/85903097.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":59055
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8466538bda3eb814e0fb34b626e8dcf5",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680562,
+    "wof:lastmodified":1582356353,
     "wof:name":"El Musheirifa el Fauq\u00e5",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/99/85903099.geojson
+++ b/data/859/030/99/85903099.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":1028721
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27520d90cac462649621a71a44f5d249",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Giv\u2019at Sha'ul",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/03/85903103.geojson
+++ b/data/859/031/03/85903103.geojson
@@ -79,6 +79,9 @@
         "qs:id":1146153
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e8ef7239518cdf0f50bf4905f685c92",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379344,
+    "wof:lastmodified":1582356352,
     "wof:name":"HaKarmel",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/07/85903107.geojson
+++ b/data/859/031/07/85903107.geojson
@@ -125,6 +125,9 @@
         "wk:page":"Hadar HaCarmel"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c379a6081063dcd824a686b4afbbd963",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680560,
+    "wof:lastmodified":1582356353,
     "wof:name":"Hadar HaKarmel",
     "wof:parent_id":421168693,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/09/85903109.geojson
+++ b/data/859/031/09/85903109.geojson
@@ -108,6 +108,9 @@
         "qs_pg:id":894375
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"50d42ebec7cefabb58a613c7fa262c28",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680560,
+    "wof:lastmodified":1582356353,
     "wof:name":"H\u0331ava\u1e95\u1e95elet",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/11/85903111.geojson
+++ b/data/859/031/11/85903111.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":898577
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbb21e42d6ada154af435e5eb9c2d8b5",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680559,
+    "wof:lastmodified":1582356352,
     "wof:name":"Kefar Nah\u0331aman",
     "wof:parent_id":421174205,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/17/85903117.geojson
+++ b/data/859/031/17/85903117.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Neve Sha'anan, Haifa"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fb8d230c2c609303a0fe7482fa016c70",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1561760002,
+    "wof:lastmodified":1582356353,
     "wof:name":"Newe Sha'anan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/25/85903125.geojson
+++ b/data/859/031/25/85903125.geojson
@@ -71,6 +71,9 @@
         "gp:id":1967837
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc8308cae77150fa701b427fb13886e4",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Qiryat Arye",
     "wof:parent_id":421202049,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/27/85903127.geojson
+++ b/data/859/031/27/85903127.geojson
@@ -101,6 +101,9 @@
         "qs_pg:id":235164
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01db1a243b0302d44f75e72a56080df2",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680559,
+    "wof:lastmodified":1582356352,
     "wof:name":"Qiryat HaTekhniyyon",
     "wof:parent_id":421168693,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/29/85903129.geojson
+++ b/data/859/031/29/85903129.geojson
@@ -111,6 +111,9 @@
         "qs_pg:id":8134
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93ad42d5d922ead2c11ed03558dc4e0e",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680559,
+    "wof:lastmodified":1582356353,
     "wof:name":"Qiryat H\u0331ayyim",
     "wof:parent_id":421168693,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/31/85903131.geojson
+++ b/data/859/031/31/85903131.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Kiryat Moshe"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90b6f95bc198ac0580570ec4f58d9bc7",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680560,
+    "wof:lastmodified":1582356353,
     "wof:name":"Qiryat Moshe",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/41/85903141.geojson
+++ b/data/859/031/41/85903141.geojson
@@ -114,6 +114,9 @@
         "wd:id":"Q3488200"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"72f7db70c93565eddf0b8ec5b13d1740",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680560,
+    "wof:lastmodified":1582356353,
     "wof:name":"Wardiya",
     "wof:parent_id":421168693,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/45/85903145.geojson
+++ b/data/859/031/45/85903145.geojson
@@ -80,6 +80,9 @@
         "qs:id":189586
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6d21f5c4418f7b6a62f7ed939f8bcee",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379344,
+    "wof:lastmodified":1582356353,
     "wof:name":"Yemin Orde",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/031/47/85903147.geojson
+++ b/data/859/031/47/85903147.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":232231
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e806e7a89b617c02e387748541304d7",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680561,
+    "wof:lastmodified":1582356353,
     "wof:name":"Zalafa el Gharb\u012bya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/63/85907163.geojson
+++ b/data/859/071/63/85907163.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1262809
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b65ae4f1830d6fa49e8fdd6dea4041c4",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680558,
+    "wof:lastmodified":1582356352,
     "wof:name":"Jewich Quarter",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/77/85907177.geojson
+++ b/data/859/071/77/85907177.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q2917976"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b2daa2b4d2e02b59b3d8090359007d1",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680558,
+    "wof:lastmodified":1582356352,
     "wof:name":"Har Nof",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/79/85907179.geojson
+++ b/data/859/071/79/85907179.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":220220
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5849a70731397fba352a5e9929cf1f5",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680558,
+    "wof:lastmodified":1582356352,
     "wof:name":"Ets Khayim",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/01/85907201.geojson
+++ b/data/859/072/01/85907201.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":43492
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2c5f5c15901a0e35f4f4b1e100a29178",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680566,
+    "wof:lastmodified":1582356353,
     "wof:name":"Shkhunat Ha-po'alim",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/03/85907203.geojson
+++ b/data/859/072/03/85907203.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":1118672
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e30f7ac0f6f6b99ff6703009f029d68",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680564,
+    "wof:lastmodified":1582356353,
     "wof:name":"Nave Sha'anan",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/07/85907207.geojson
+++ b/data/859/072/07/85907207.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q12040825"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6ac7f135e6b949afd339fed2dfd3e6d",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680565,
+    "wof:lastmodified":1582356353,
     "wof:name":"Neve Granot",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/19/85907219.geojson
+++ b/data/859/072/19/85907219.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":14512
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43d72f1c60e9189951f824fbbe69348c",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680565,
+    "wof:lastmodified":1582356353,
     "wof:name":"Gonen Khet",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/21/85907221.geojson
+++ b/data/859/072/21/85907221.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":1252059
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff24dccb1e229f8ea46a033e0a34c141",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680565,
+    "wof:lastmodified":1582356353,
     "wof:name":"Gonen Gimel",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/33/85907233.geojson
+++ b/data/859/072/33/85907233.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1182151
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6ad884c5ed9461df8fe88763c53b334",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680564,
+    "wof:lastmodified":1582356353,
     "wof:name":"Ramat Sharet",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/39/85907239.geojson
+++ b/data/859/072/39/85907239.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":1262810
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3d4e22f83c833c07e7cd37443b81729d",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680566,
+    "wof:lastmodified":1582356353,
     "wof:name":"Giv'at Beit Ha-kerem",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/19/85907319.geojson
+++ b/data/859/073/19/85907319.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":902474
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"46fc0fa32fa6f6fd8dd2592caba2944f",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680562,
+    "wof:lastmodified":1582356353,
     "wof:name":"Neve Rasko",
     "wof:parent_id":421174205,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/21/85907321.geojson
+++ b/data/859/073/21/85907321.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q5636377"
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8062b89211664aa31f35405cd83c9fe2",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680563,
+    "wof:lastmodified":1582356353,
     "wof:name":"Ha-kfar Ha-yarok",
     "wof:parent_id":421180791,
     "wof:placetype":"neighbourhood",

--- a/data/859/073/23/85907323.geojson
+++ b/data/859/073/23/85907323.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":902476
     },
     "wof:country":"IL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"90f65d14ad4349a93aa0deabfce2aadd",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566680563,
+    "wof:lastmodified":1582356353,
     "wof:name":"Neve Magen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.