### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/167/965/421167965.geojson
+++ b/data/421/167/965/421167965.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632315,
-        85672545,
-        1108720807
+        1108720807,
+        85672545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421167965,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Burj Al Naqoura",
     "wof:parent_id":1108720807,
     "wof:placetype":"locality",

--- a/data/421/167/965/421167965.geojson
+++ b/data/421/167/965/421167965.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u062c \u0627\u0644\u0646\u0627\u0642\u0648\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Burj Al Naqoura"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421167965,
-    "wof:lastmodified":1566680634,
-    "wof:name":"\u0628\u0631\u062c \u0627\u0644\u0646\u0627\u0642\u0648\u0631\u0629",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Burj Al Naqoura",
     "wof:parent_id":1108720807,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/186/377/421186377.geojson
+++ b/data/421/186/377/421186377.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632315,
-        85672545,
-        1108720839
+        1108720839,
+        85672545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186377,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Maisat",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",

--- a/data/421/186/377/421186377.geojson
+++ b/data/421/186/377/421186377.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u064a\u0633\u0627\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Maisat"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186377,
-    "wof:lastmodified":1566680654,
-    "wof:name":"\u0627\u0644\u0645\u064a\u0633\u0627\u062a",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Maisat",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/188/233/421188233.geojson
+++ b/data/421/188/233/421188233.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421188233,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sur",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/421/188/233/421188233.geojson
+++ b/data/421/188/233/421188233.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0635\u0648\u0631"
+    ],
+    "name:eng_x_preferred":[
+        "Sur"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IL",
     "wof:created":1459009538,
-    "wof:geomhash":"c6586ceb49be2a7726aa81b866408e07",
+    "wof:geomhash":"cef612cb1c9d8dd47625c5469ee764af",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421188233,
-    "wof:lastmodified":1476124969,
-    "wof:name":"\u0635\u0648\u0631",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Sur",
     "wof:parent_id":85672545,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/190/563/421190563.geojson
+++ b/data/421/190/563/421190563.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0645\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Amarah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190563,
-    "wof:lastmodified":1566680662,
-    "wof:name":"\u0639\u0645\u0627\u0631\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Amarah",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/190/563/421190563.geojson
+++ b/data/421/190/563/421190563.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632315,
-        85672545,
-        1108720839
+        1108720839,
+        85672545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190563,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Amarah",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",

--- a/data/421/190/579/421190579.geojson
+++ b/data/421/190/579/421190579.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"35.1948645,33.07892,35.1948645,33.07892",
+    "geom:bbox":"35.194865,33.07892,35.194865,33.07892",
     "geom:latitude":33.07892,
     "geom:longitude":35.194865,
     "iso:country":"IL",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632315,
-        85672545,
-        1108720807
+        1108720807,
+        85672545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"IL",
     "wof:created":1459009662,
-    "wof:geomhash":"af08e76a4abc56730089d2887b899142",
+    "wof:geomhash":"3642a5501a9c24aa92e4383f031df9ad",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190579,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423082,
     "wof:name":"Aalma Ech Chaab",
     "wof:parent_id":1108720807,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    35.1948645,
+    35.194865,
     33.07892,
-    35.1948645,
+    35.194865,
     33.07892
 ],
-  "geometry": {"coordinates":[35.1948645,33.07892],"type":"Point"}
+  "geometry": {"coordinates":[35.194865,33.07892],"type":"Point"}
 }

--- a/data/421/190/579/421190579.geojson
+++ b/data/421/190/579/421190579.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0644\u0645\u0627 \u0627\u0644\u0634\u0639\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Aalma Ech Chaab"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190579,
-    "wof:lastmodified":1566680663,
-    "wof:name":"\u0639\u0644\u0645\u0627 \u0627\u0644\u0634\u0639\u0628",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Aalma Ech Chaab",
     "wof:parent_id":1108720807,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/199/689/421199689.geojson
+++ b/data/421/199/689/421199689.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0643\u0641\u0631\u0643\u0644\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Kafr Kila"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421199689,
-    "wof:lastmodified":1566680665,
-    "wof:name":"\u0643\u0641\u0631\u0643\u0644\u0627",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Kafr Kila",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/199/689/421199689.geojson
+++ b/data/421/199/689/421199689.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632315,
-        85672545,
-        1108720839
+        1108720839,
+        85672545
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421199689,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Kafr Kila",
     "wof:parent_id":1108720839,
     "wof:placetype":"locality",

--- a/data/421/202/303/421202303.geojson
+++ b/data/421/202/303/421202303.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421202303,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Marjayoun",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/421/202/303/421202303.geojson
+++ b/data/421/202/303/421202303.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0631\u062c\u0639\u064a\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Marjayoun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IL",
     "wof:created":1459010112,
-    "wof:geomhash":"3aea3c0848dfab78f283b2102b69264f",
+    "wof:geomhash":"ea21010a4a82cb0ff79d5be3e39be2c2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421202303,
-    "wof:lastmodified":1476124970,
-    "wof:name":"\u0645\u0631\u062c\u0639\u064a\u0648\u0646",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Marjayoun",
     "wof:parent_id":85672545,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/203/693/421203693.geojson
+++ b/data/421/203/693/421203693.geojson
@@ -13,6 +13,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0646\u062a \u062c\u0628\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Bint Jbeil"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -44,7 +50,7 @@
     },
     "wof:country":"IL",
     "wof:created":1459010160,
-    "wof:geomhash":"d5e8d7b678c0b50888234bac61f253fd",
+    "wof:geomhash":"b9a2e54d960390eb5ae9d3e7e8babb37",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -54,8 +60,8 @@
         }
     ],
     "wof:id":421203693,
-    "wof:lastmodified":1476124968,
-    "wof:name":"\u0628\u0646\u062a \u062c\u0628\u064a\u0644",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Bint Jbeil",
     "wof:parent_id":85672545,
     "wof:placetype":"county",
     "wof:repo":"whosonfirst-data-admin-il",

--- a/data/421/203/693/421203693.geojson
+++ b/data/421/203/693/421203693.geojson
@@ -60,7 +60,7 @@
         }
     ],
     "wof:id":421203693,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423088,
     "wof:name":"Bint Jbeil",
     "wof:parent_id":85672545,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.