### PR TITLE
il concordances, placetype local, and more

### DIFF
--- a/data/110/872/080/3/1108720803.geojson
+++ b/data/110/872/080/3/1108720803.geojson
@@ -266,7 +266,7 @@
         }
     ],
     "wof:id":1108720803,
-    "wof:lastmodified":1694498049,
+    "wof:lastmodified":1695886676,
     "wof:name":"Sea of Galilee",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/080/5/1108720805.geojson
+++ b/data/110/872/080/5/1108720805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033343,
-    "geom:area_square_m":348472299.783657,
+    "geom:area_square_m":348472155.316828,
     "geom:bbox":"34.809209,32.190998,35.051422,32.412854",
     "geom:latitude":32.30696,
     "geom:longitude":34.925652,
@@ -88,12 +88,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HM.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124689,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"c44c927a585cb01b81197adcb5d9b0e6",
+    "wof:geomhash":"d81e71eed1abf4959ca55eb12b153318",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108720805,
-    "wof:lastmodified":1642551773,
+    "wof:lastmodified":1695886516,
     "wof:name":"Sharon",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/080/7/1108720807.geojson
+++ b/data/110/872/080/7/1108720807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.089434,
-    "geom:area_square_m":928080516.049739,
+    "geom:area_square_m":928080466.401526,
     "geom:bbox":"35.066077,32.748645,35.43914,33.107918",
     "geom:latitude":32.940535,
     "geom:longitude":35.241943,
@@ -70,12 +70,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HZ.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124690,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"6e6e2d48778983421915a8dd813fee71",
+    "wof:geomhash":"657395a1dc231689d87804cf0961ae29",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108720807,
-    "wof:lastmodified":1642551773,
+    "wof:lastmodified":1695886517,
     "wof:name":"Akko",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/081/1/1108720811.geojson
+++ b/data/110/872/081/1/1108720811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.111299,
-    "geom:area_square_m":1154059223.963784,
+    "geom:area_square_m":1154059223.964239,
     "geom:bbox":"35.6134911487,32.6820527632,35.8954026113,33.3338961181",
     "geom:latitude":33.011244,
     "geom:longitude":35.741956,
@@ -94,12 +94,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HZ.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124692,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"733d0014a683df98053e3c7181f11ba7",
+    "wof:geomhash":"9d071f3c2fa077edbe56523c6707c04a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -123,7 +124,7 @@
         }
     ],
     "wof:id":1108720811,
-    "wof:lastmodified":1582356364,
+    "wof:lastmodified":1695886802,
     "wof:name":"Golan",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/872/081/3/1108720813.geojson
+++ b/data/110/872/081/3/1108720813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030871,
-    "geom:area_square_m":324141733.613123,
+    "geom:area_square_m":324141733.613141,
     "geom:bbox":"34.6647840417,31.7572948226,34.8718905658,32.0109774086",
     "geom:latitude":31.881074,
     "geom:longitude":34.767283,
@@ -187,12 +187,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HM.RH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124695,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"16515bfa76e6514160b88e1cff615f56",
+    "wof:geomhash":"69ce6a1beaf54b1664847f45729c9bd5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -202,7 +203,7 @@
         }
     ],
     "wof:id":1108720813,
-    "wof:lastmodified":1582356367,
+    "wof:lastmodified":1695886805,
     "wof:name":"Rehovot",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/081/5/1108720815.geojson
+++ b/data/110/872/081/5/1108720815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032311,
-    "geom:area_square_m":339105355.488294,
+    "geom:area_square_m":339105189.508137,
     "geom:bbox":"34.809626,31.808827,35.040839,32.02731",
     "geom:latitude":31.924385,
     "geom:longitude":34.921717,
@@ -208,12 +208,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HM.RM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124696,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"a4e1ee03e276fd7fc4a1ff1a62bbe2bc",
+    "wof:geomhash":"bada4ca1de58a8eb654721eb680b1b51",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -223,7 +224,7 @@
         }
     ],
     "wof:id":1108720815,
-    "wof:lastmodified":1636502613,
+    "wof:lastmodified":1695886068,
     "wof:name":"Ramla",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/081/7/1108720817.geojson
+++ b/data/110/872/081/7/1108720817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.215561,
-    "geom:area_square_m":12916675539.780102,
+    "geom:area_square_m":12916675401.271494,
     "geom:bbox":"34.267257,29.490483,35.426245,31.503609",
     "geom:latitude":30.752615,
     "geom:longitude":34.873288,
@@ -70,12 +70,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HD.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124697,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"64cba7279490817ec1a785e1d7050261",
+    "wof:geomhash":"9e30a8630b400f2069d9e39d28e25503",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108720817,
-    "wof:lastmodified":1627522199,
+    "wof:lastmodified":1695886677,
     "wof:name":"Be'er Sheva",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/081/9/1108720819.geojson
+++ b/data/110/872/081/9/1108720819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054856,
-    "geom:area_square_m":571825523.346975,
+    "geom:area_square_m":571825523.347106,
     "geom:bbox":"34.869135441,32.3722647574,35.210783,32.7679787601",
     "geom:latitude":32.539991,
     "geom:longitude":34.997208,
@@ -193,12 +193,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HA.HD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124698,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"41cfb230894604f03547d411a986f7a3",
+    "wof:geomhash":"95874dd77036b1c6aa18fe1de4782d12",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -208,7 +209,7 @@
         }
     ],
     "wof:id":1108720819,
-    "wof:lastmodified":1582356363,
+    "wof:lastmodified":1695886802,
     "wof:name":"Hadera",
     "wof:parent_id":85672535,
     "wof:placetype":"county",

--- a/data/110/872/082/1/1108720821.geojson
+++ b/data/110/872/082/1/1108720821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027034,
-    "geom:area_square_m":283127742.791131,
+    "geom:area_square_m":283127773.998369,
     "geom:bbox":"34.836844,32.001279,35.023867,32.248868",
     "geom:latitude":32.11724,
     "geom:longitude":34.924525,
@@ -70,12 +70,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HM.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124699,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"d17077475622d58c051cc1c3450c65ed",
+    "wof:geomhash":"451e6785601aff1cc1c2bc98e84610de",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108720821,
-    "wof:lastmodified":1642551831,
+    "wof:lastmodified":1695886538,
     "wof:name":"Petah Tiqwa",
     "wof:parent_id":85672541,
     "wof:placetype":"county",

--- a/data/110/872/082/3/1108720823.geojson
+++ b/data/110/872/082/3/1108720823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062088,
-    "geom:area_square_m":652820219.981702,
+    "geom:area_square_m":652820219.981745,
     "geom:bbox":"34.820337,31.603192,35.265668,31.882742",
     "geom:latitude":31.752476,
     "geom:longitude":35.031659,
@@ -275,6 +275,7 @@
         "hasc:id":"IL.JM.JM",
         "wd:id":"Q192232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85672551
     ],
@@ -283,7 +284,7 @@
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"44de3e283ede003587791b7776754f98",
+    "wof:geomhash":"d533212bdf55cab9e19c6e1094645b56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -293,7 +294,7 @@
         }
     ],
     "wof:id":1108720823,
-    "wof:lastmodified":1690931950,
+    "wof:lastmodified":1695886068,
     "wof:name":"Jerusalem",
     "wof:parent_id":85672551,
     "wof:placetype":"county",

--- a/data/110/872/082/5/1108720825.geojson
+++ b/data/110/872/082/5/1108720825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050896,
-    "geom:area_square_m":529229023.099658,
+    "geom:area_square_m":529229023.099458,
     "geom:bbox":"35.3755397212,32.595169126,35.6752182353,32.9604984428",
     "geom:latitude":32.761372,
     "geom:longitude":35.498047,
@@ -88,12 +88,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HZ.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124702,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"4cdb7bd4adccd6abaacc99b98ca10c8b",
+    "wof:geomhash":"c390a9da38c4b07bd1235e694e4d1e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108720825,
-    "wof:lastmodified":1582356362,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kinneret",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/082/9/1108720829.geojson
+++ b/data/110/872/082/9/1108720829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114706,
-    "geom:area_square_m":1194797015.710736,
+    "geom:area_square_m":1194797382.065293,
     "geom:bbox":"35.027664,32.386967,35.580338,32.816183",
     "geom:latitude":32.607481,
     "geom:longitude":35.325344,
@@ -82,12 +82,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HZ.JZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124703,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"4fda7cb4cd5739dbcfaa516de2f498ab",
+    "wof:geomhash":"0ef47b0cdecbfe427aab6f28339833b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108720829,
-    "wof:lastmodified":1627522202,
+    "wof:lastmodified":1695886682,
     "wof:name":"Yizre'el",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/083/1/1108720831.geojson
+++ b/data/110/872/083/1/1108720831.geojson
@@ -416,7 +416,7 @@
         }
     ],
     "wof:id":1108720831,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886801,
     "wof:name":"Dead Sea",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/083/3/1108720833.geojson
+++ b/data/110/872/083/3/1108720833.geojson
@@ -416,7 +416,7 @@
         }
     ],
     "wof:id":1108720833,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886801,
     "wof:name":"Dead Sea",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/110/872/083/5/1108720835.geojson
+++ b/data/110/872/083/5/1108720835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028287,
-    "geom:area_square_m":294133585.838866,
+    "geom:area_square_m":294133660.074728,
     "geom:bbox":"34.952408,32.634425,35.161365,32.887717",
     "geom:latitude":32.761407,
     "geom:longitude":35.062018,
@@ -284,12 +284,13 @@
         "hasc:id":"IL.HA.HF",
         "wd:id":"Q185845"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124706,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"5f6b5d220042b0b4168faee7a02d02f7",
+    "wof:geomhash":"6152f116860ad974516c804dbbb65dcd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -299,7 +300,7 @@
         }
     ],
     "wof:id":1108720835,
-    "wof:lastmodified":1690931950,
+    "wof:lastmodified":1695886801,
     "wof:name":"Haifa",
     "wof:parent_id":85672535,
     "wof:placetype":"county",

--- a/data/110/872/083/7/1108720837.geojson
+++ b/data/110/872/083/7/1108720837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016444,
-    "geom:area_square_m":172279551.049129,
+    "geom:area_square_m":172279551.049248,
     "geom:bbox":"34.733099,31.98878,34.87583,32.202197",
     "geom:latitude":32.08247,
     "geom:longitude":34.809661,
@@ -266,6 +266,7 @@
         "hasc:id":"IL.TA.TA",
         "wd:id":"Q192811"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85672549
     ],
@@ -274,7 +275,7 @@
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"a61c05481a345cb4f3ec7747a114361a",
+    "wof:geomhash":"6a0cb745acc7e802eb62d1f5abe2cda3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -284,7 +285,7 @@
         }
     ],
     "wof:id":1108720837,
-    "wof:lastmodified":1690931949,
+    "wof:lastmodified":1695886068,
     "wof:name":"Tel Aviv",
     "wof:parent_id":85672549,
     "wof:placetype":"county",

--- a/data/110/872/083/9/1108720839.geojson
+++ b/data/110/872/083/9/1108720839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064585,
-    "geom:area_square_m":669319175.219997,
+    "geom:area_square_m":669319121.062018,
     "geom:bbox":"35.361892,32.880052,35.685195,33.290674",
     "geom:latitude":33.059198,
     "geom:longitude":35.543543,
@@ -70,12 +70,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HZ.ZF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124709,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"ddc0a000343d572f03c1fc91ed29f7a4",
+    "wof:geomhash":"bb1b395cb169e695ccb599fd22242d48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108720839,
-    "wof:lastmodified":1627522200,
+    "wof:lastmodified":1695886677,
     "wof:name":"Zefat",
     "wof:parent_id":85672545,
     "wof:placetype":"county",

--- a/data/110/872/084/1/1108720841.geojson
+++ b/data/110/872/084/1/1108720841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12039,
-    "geom:area_square_m":1267770885.923903,
+    "geom:area_square_m":1267771010.153569,
     "geom:bbox":"34.468576,31.407478,34.960956,31.862531",
     "geom:latitude":31.610661,
     "geom:longitude":34.729511,
@@ -70,12 +70,13 @@
     "wof:concordances":{
         "hasc:id":"IL.HD.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"IL",
     "wof:created":1476124711,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"dddc29a8994ae8c858f3e901d24f49bc",
+    "wof:geomhash":"d832f82ff72106018b7f3fe1626773fd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108720841,
-    "wof:lastmodified":1627522199,
+    "wof:lastmodified":1695886677,
     "wof:name":"Ashqelon",
     "wof:parent_id":85672531,
     "wof:placetype":"county",

--- a/data/856/323/15/85632315.geojson
+++ b/data/856/323/15/85632315.geojson
@@ -1346,6 +1346,7 @@
         "hasc:id":"IL",
         "icao:code":"4X",
         "ioc:id":"ISR",
+        "iso:code":"IL",
         "itu:id":"ISR",
         "loc:id":"n79003285",
         "m49:code":"376",
@@ -1359,6 +1360,7 @@
         "wd:id":"Q801",
         "wmo:id":"IS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IL",
     "wof:country_alpha3":"ISR",
     "wof:geom_alt":[
@@ -1385,7 +1387,7 @@
         "ara",
         "eng"
     ],
-    "wof:lastmodified":1694639638,
+    "wof:lastmodified":1695881300,
     "wof:name":"Israel",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/725/31/85672531.geojson
+++ b/data/856/725/31/85672531.geojson
@@ -357,12 +357,14 @@
         "gn:id":294952,
         "gp:id":2345791,
         "hasc:id":"IL.HD",
+        "iso:code":"IL-D",
         "iso:id":"IL-D",
         "qs_pg:id":913650,
         "unlc:id":"IL-D",
         "wd:id":"Q188781",
         "wk:page":"Southern District (Israel)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -385,7 +387,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1694493263,
+    "wof:lastmodified":1695885132,
     "wof:name":"Southern",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/35/85672535.geojson
+++ b/data/856/725/35/85672535.geojson
@@ -375,11 +375,13 @@
         "gn:id":294800,
         "gp:id":2345794,
         "hasc:id":"IL.HA",
+        "iso:code":"IL-HA",
         "iso:id":"IL-HA",
         "qs_pg:id":1168669,
         "wd:id":"Q185845",
         "wk:page":"Haifa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IL",
     "wof:geom_alt":[
         "meso",
@@ -402,7 +404,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1694493222,
+    "wof:lastmodified":1695884653,
     "wof:name":"Haifa",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/41/85672541.geojson
+++ b/data/856/725/41/85672541.geojson
@@ -330,12 +330,14 @@
         "gn:id":294904,
         "gp:id":2345792,
         "hasc:id":"IL.HM",
+        "iso:code":"IL-M",
         "iso:id":"IL-M",
         "qs_pg:id":1168667,
         "unlc:id":"IL-M",
         "wd:id":"Q188785",
         "wk:page":"Central District (Israel)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -358,7 +360,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884937,
     "wof:name":"Central",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/45/85672545.geojson
+++ b/data/856/725/45/85672545.geojson
@@ -377,11 +377,13 @@
         "gn:id":294824,
         "gp:id":2345793,
         "hasc:id":"IL.HZ",
+        "iso:code":"IL-Z",
         "iso:id":"IL-Z",
         "qs_pg:id":1168668,
         "wd:id":"Q189942",
         "wk:page":"Northern District (Israel)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"IL",
     "wof:geom_alt":[
         "quattroshapes",
@@ -404,7 +406,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884937,
     "wof:name":"Northern",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/49/85672549.geojson
+++ b/data/856/725/49/85672549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016444,
-    "geom:area_square_m":172279551.049129,
+    "geom:area_square_m":172279551.049248,
     "geom:bbox":"34.733099,31.98878,34.87583,32.202197",
     "geom:latitude":32.08247,
     "geom:longitude":34.809661,
@@ -346,12 +346,14 @@
         "gn:id":293396,
         "gp:id":2345795,
         "hasc:id":"IL.TA",
+        "iso:code":"IL-TA",
         "iso:id":"IL-TA",
         "qs_pg:id":240034,
         "unlc:id":"IL-TA",
         "wd:id":"Q192811",
         "wk:page":"Tel Aviv District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108720837
     ],
@@ -360,7 +362,7 @@
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"a61c05481a345cb4f3ec7747a114361a",
+    "wof:geomhash":"6a0cb745acc7e802eb62d1f5abe2cda3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -377,7 +379,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1690931948,
+    "wof:lastmodified":1695884938,
     "wof:name":"Tel Aviv",
     "wof:parent_id":85632315,
     "wof:placetype":"region",

--- a/data/856/725/51/85672551.geojson
+++ b/data/856/725/51/85672551.geojson
@@ -380,12 +380,14 @@
         "gn:id":293198,
         "gp:id":2345796,
         "hasc:id":"IL.JM",
+        "iso:code":"IL-JM",
         "iso:id":"IL-JM",
         "qs_pg:id":1168670,
         "unlc:id":"IL-JM",
         "wd:id":"Q192232",
         "wk:page":"Jerusalem District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108720823
     ],
@@ -411,7 +413,7 @@
         "heb",
         "ara"
     ],
-    "wof:lastmodified":1694493260,
+    "wof:lastmodified":1695884937,
     "wof:name":"Jerusalem",
     "wof:parent_id":85632315,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.